### PR TITLE
Add CI workflow to build native libs

### DIFF
--- a/.github/workflows/build_and_update.yaml
+++ b/.github/workflows/build_and_update.yaml
@@ -1,0 +1,187 @@
+name: Build Native Libraries
+
+on:
+  push:
+    paths:
+      - 'dependency/**'
+      - 'projects/**'
+      - 'src/**'
+  pull_request:
+    paths:
+      - 'dependency/**'
+      - 'projects/**'
+      - 'src/**'
+
+jobs:
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Build
+        run: |
+          cd projects/CMake
+          cmake -S . -B build_x86 -A Win32
+          cmake -S . -B build_x86_64 -A x64
+          cmake --build build_x86 --config Release
+          cmake --build build_x86_64 --config Release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VorbisPluginWindowsArtifacts
+          path: |
+            out/Release/Plugins/Windows/x86/VorbisPlugin.dll
+            out/Release/Plugins/Windows/x86_64/VorbisPlugin.dll
+
+  build_android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          cmake-version: '3.25.2'
+      - name: Set execution permissions for gradlew
+        run: chmod +x projects/Android/gradlew
+      - name: Build Gradle project
+        run: |
+          cd projects/Android
+          ./gradlew assembleRelease
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VorbisPluginAndroidArtifacts
+          path: |
+            out/RelWithDebInfo/Plugins/Android/arm64-v8a/libVorbisPlugin.so
+            out/RelWithDebInfo/Plugins/Android/armeabi-v7a/libVorbisPlugin.so
+
+  build_macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install CMake
+        run: brew install cmake
+      - name: Build
+        run: |
+          cd projects/CMake
+          cmake -S . -B buildOSX -G Xcode -DVORBIS_OSX=1 -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+          cmake --build buildOSX --config Release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VorbisPluginMacOSArtifacts
+          path: |
+            out/Release/Plugins/Darwin/arm64/libVorbisPlugin.dylib
+
+  build_ios:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install CMake
+        run: brew install cmake
+      - name: Build
+        run: |
+          cd projects/CMake
+          cmake -S . -B buildIOS -G Xcode -DCMAKE_TOOLCHAIN_FILE=../../dependency/cmake-ios-toolchain/ios.toolchain.cmake -DPLATFORM=OS64 -DVORBIS_IOS=1
+          cmake --build buildIOS --config Release --target VorbisPlugin
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VorbisPluginIOSArtifacts
+          path: |
+            out/Release/Plugins/iOS/arm64/libVorbisPlugin.a
+            out/Release/Plugins/iOS/arm64/libvorbis.a
+            out/Release/Plugins/iOS/arm64/libvorbisfile.a
+            out/Release/Plugins/iOS/arm64/libogg.a
+
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install CMake
+        run: sudo apt-get install cmake
+      - name: Build
+        run: |
+          cd projects/CMake
+          cmake -S . -B buildLinux -G "Unix Makefiles" -DVORBIS_LINUX=1
+          cmake --build buildLinux --config Release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VorbisPluginLinuxArtifacts
+          path: |
+            out/Plugins/Linux/x86_64/libVorbisPlugin.so
+
+  commit_and_push_native_libraries:
+    needs: [build_windows, build_android, build_macos, build_ios, build_linux]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          submodules: recursive
+      - name: Download artifacts windows
+        uses: actions/download-artifact@v4
+        with:
+          name: VorbisPluginWindowsArtifacts
+          path: out/Plugins/Windows
+      - name: Download artifacts android
+        uses: actions/download-artifact@v4
+        with:
+          name: VorbisPluginAndroidArtifacts
+          path: out/Plugins/Android
+      - name: Download artifacts macos
+        uses: actions/download-artifact@v4
+        with:
+          name: VorbisPluginMacOSArtifacts
+          path: out/Plugins/Darwin
+      - name: Download artifacts ios
+        uses: actions/download-artifact@v4
+        with:
+          name: VorbisPluginIOSArtifacts
+          path: out/Plugins/iOS
+      - name: Download artifacts linux
+        uses: actions/download-artifact@v4
+        with:
+          name: VorbisPluginLinuxArtifacts
+          path: out/Plugins/Linux
+      - name: Commit and push native libraries
+        env:
+          MY_SECRET: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          mkdir -p unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/Linux/x86_64
+          cp -f out/Plugins/Windows/x86/VorbisPlugin.dll unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/Windows/x86/VorbisPlugin.dll
+          cp -f out/Plugins/Windows/x86_64/VorbisPlugin.dll unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/Windows/x86_64/VorbisPlugin.dll
+          cp -f out/Plugins/Android/arm64-v8a/libVorbisPlugin.so unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/Android/libs/arm64-v8a/libVorbisPlugin.so
+          cp -f out/Plugins/Android/armeabi-v7a/libVorbisPlugin.so unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/Android/libs/armeabi-v7a/libVorbisPlugin.so
+          cp -f out/Plugins/Darwin/arm64/libVorbisPlugin.dylib unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/OSX/libVorbisPlugin.dylib
+          cp -f out/Plugins/iOS/arm64/libVorbisPlugin.a unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/iOS/libVorbisPlugin.a
+          cp -f out/Plugins/iOS/arm64/libvorbis.a unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/iOS/libvorbis.a
+          cp -f out/Plugins/iOS/arm64/libvorbisfile.a unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/iOS/libvorbisfile.a
+          cp -f out/Plugins/iOS/arm64/libogg.a unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/iOS/libogg.a
+          cp -f out/Plugins/Linux/x86_64/libVorbisPlugin.so unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins/Linux/x86_64/libVorbisPlugin.so
+          git add unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git commit -m "Update native libraries" || echo "No changes to commit"
+          git push https://token:$MY_SECRET@github.com/${{ github.repository }} HEAD:${{ github.ref }}


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow to build plugin libraries for all platforms and update them in the Unity project

## Testing
- `git commit -m "Add CI workflow to build and update native libraries"`


------
https://chatgpt.com/codex/tasks/task_e_685576d015fc832f81409a41ec74108a