### PR TITLE
Align CI and build system with RLottie pipeline

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -3,14 +3,14 @@ name: Build and Test
 on:
   push:
     branches:
-      - master
+      - dev
     paths:
       - 'dependency/**'
       - 'projects/**'
       - 'src/**'
   pull_request:
     branches:
-      - master
+      - dev
 
 jobs:
   build_windows:
@@ -24,13 +24,13 @@ jobs:
       - name: Build
         run: |
           cd projects/CMake
-          cmake -S . -B ./build_x86 -A Win32
-          cmake -S . -B ./build_x86_64 -A x64
+          cmake -S . -B ./build_x86    -A Win32 -DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON
+          cmake -S . -B ./build_x86_64 -A x64   -DCMAKE_C_STANDARD=11 -DCMAKE_C_STANDARD_REQUIRED=ON
           cmake --build ./build_x86 --config Release
           cmake --build ./build_x86_64 --config Release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VorbisPluginWindowsArtifacts
           path: |
@@ -51,41 +51,33 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      # - name: Setup CMake
-      #   uses: jwlawson/actions-setup-cmake@v1.14
-      #   with:
-      #     cmake-version: '3.22.1'
-
       - name: Install Android SDK Command-line Tools
         run: |
           mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
           curl -fo sdk-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
           unzip sdk-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
           mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+
       - name: Accept Licenses
         run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
+
       - name: Install CMake and NDK
         run: |
           $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1" "ndk;27.2.12479018"
-        
-      # - name: Set up Android SDK
-      #   uses: android-actions/setup-android@v2
-      #   with:
-      #     api-level: 28
-      #     cmake-version: '3.22.1'
-      #     ndk-version: '27.2.12479018'
 
       - name: Set execution permissions for gradlew
         run: chmod +x projects/Android/gradlew
 
       - name: Build Gradle project
         run: |
+          sudo apt-get update
+          sudo apt-get install -y tree
           cd projects/Android
-          ./gradlew clean assembleRelease
+          ./gradlew -PANDROID_16K_PAGE=ON assembleRelease
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VorbisPluginAndroidArtifacts
           path: |
@@ -102,23 +94,49 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install CMake
-        run: brew install cmake
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          cmake-version: '3.29.6'
 
       - name: Build
+        shell: bash
         run: |
+          set -euxo pipefail
           cd projects/CMake
+
           cmake -S . -B ./buildOSX -G Xcode -DVORBIS_OSX=1 -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
           cmake --build ./buildOSX --config Release
+
+          cmake -S . -B ./buildOSX_arm64 -G Xcode -DVORBIS_OSX=1 -DCMAKE_OSX_ARCHITECTURES=arm64
+          cmake --build ./buildOSX_arm64 --config Release
+
+          cmake -S . -B ./buildOSX_x86_64 -G Xcode -DVORBIS_OSX=1 -DCMAKE_OSX_ARCHITECTURES=x86_64
+          cmake --build ./buildOSX_x86_64 --config Release
+
+          ARM64_DYLIB="$(find ./buildOSX_arm64 -type f -name libVorbisPlugin.dylib | head -n1)"
+          X64_DYLIB="$(find ./buildOSX_x86_64 -type f -name libVorbisPlugin.dylib | head -n1)"
+
+          mkdir -p ../../out/Release/Plugins/Darwin/arm64
+          mkdir -p ../../out/Release/Plugins/Darwin/x86_64
+
+          cp "$ARM64_DYLIB" ../../out/Release/Plugins/Darwin/arm64/
+          cp "$X64_DYLIB" ../../out/Release/Plugins/Darwin/x86_64/
+
+          lipo -create "$ARM64_DYLIB" "$X64_DYLIB" -output ../../out/Release/Plugins/Darwin/libVorbisPlugin.dylib
+
           brew install tree
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VorbisPluginMacOSArtifacts
           path: |
             out/Release/Plugins/Darwin/arm64/libVorbisPlugin.dylib
+            out/Release/Plugins/Darwin/x86_64/libVorbisPlugin.dylib
+            out/Release/Plugins/Darwin/libVorbisPlugin.dylib
+          if-no-files-found: error
 
   build_ios:
     runs-on: macos-latest
@@ -128,8 +146,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install CMake
-        run: brew install cmake
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@v1.14
+        with:
+          cmake-version: '3.29.6'
 
       - name: Build
         run: |
@@ -140,14 +160,15 @@ jobs:
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VorbisPluginIOSArtifacts
           path: |
-            out/Release/Plugins/iOS/arm64/libVorbisPlugin.a
-            out/Release/Plugins/iOS/arm64/libvorbis.a
-            out/Release/Plugins/iOS/arm64/libvorbisfile.a
-            out/Release/Plugins/iOS/arm64/libogg.a
+            out/Release/Plugins/iOS/*/libVorbisPlugin.a
+            out/Release/Plugins/iOS/*/libvorbis.a
+            out/Release/Plugins/iOS/*/libvorbisfile.a
+            out/Release/Plugins/iOS/*/libvorbisenc.a
+            out/Release/Plugins/iOS/*/libogg.a
 
   build_linux:
     runs-on: ubuntu-latest
@@ -157,8 +178,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install CMake
-        run: sudo apt-get install cmake
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake tree
 
       - name: Build
         run: |
@@ -168,75 +191,169 @@ jobs:
           tree ../../out
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: VorbisPluginLinuxArtifacts
           path: |
             out/Plugins/Linux/x86_64/libVorbisPlugin.so
 
-  commit_and_push_native_libraries:
-    needs: [build_windows, build_android, build_macos, build_ios, build_linux]
+  build_webgl:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: dev
           submodules: recursive
 
+      - name: Install Emscripten 3.1.39
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install 3.1.39
+          ./emsdk activate 3.1.39
+          source ./emsdk_env.sh
+          emcc -v || true
+
+      - name: Build WebGL static libs (.a)
+        run: |
+          source emsdk/emsdk_env.sh
+          cd projects/CMake
+          emcmake cmake -S . -B ./buildWebGL \
+            -DVORBIS_WEB_ASSEMBLY=1 \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=OFF
+          cmake --build ./buildWebGL --config Release
+          cd ../..
+          ls -al out/Plugins/WebGL || true
+          emar t out/Plugins/WebGL/libVorbisPlugin.a || true
+          emar t out/Plugins/WebGL/libvorbis.a || true
+          emar t out/Plugins/WebGL/libvorbisfile.a || true
+          emar t out/Plugins/WebGL/libvorbisenc.a || true
+          emar t out/Plugins/WebGL/libogg.a || true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: VorbisPluginWebGLArtifacts
+          path: |
+            out/Plugins/WebGL/libVorbisPlugin.a
+            out/Plugins/WebGL/libvorbis.a
+            out/Plugins/WebGL/libvorbisfile.a
+            out/Plugins/WebGL/libvorbisenc.a
+            out/Plugins/WebGL/libogg.a
+
+  commit_and_push_native_libraries:
+    needs: [build_windows, build_android, build_macos, build_ios, build_linux, build_webgl]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Ensure dev branch exists
+        run: |
+          if git ls-remote --exit-code origin dev >/dev/null 2>&1; then
+            git checkout dev
+          elif git show-ref --verify --quiet refs/heads/dev; then
+            git checkout dev
+          else
+            git checkout -b dev
+          fi
+
       - name: Download artifacts windows
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: VorbisPluginWindowsArtifacts
           path: out/Plugins/Windows
 
       - name: Download artifacts android
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: VorbisPluginAndroidArtifacts
           path: out/Plugins/Android
 
       - name: Download artifacts macos
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: VorbisPluginMacOSArtifacts
           path: out/Plugins/Darwin
 
       - name: Download artifacts ios
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: VorbisPluginIOSArtifacts
           path: out/Plugins/iOS
 
       - name: Download artifacts linux
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: VorbisPluginLinuxArtifacts
           path: out/Plugins/Linux
+
+      - name: Download artifacts webgl
+        uses: actions/download-artifact@v4
+        with:
+          name: VorbisPluginWebGLArtifacts
+          path: out/Plugins/WebGL
 
       - name: Commit and push native libraries
         env:
           MY_SECRET: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
-          cp -f out/Plugins/Windows/x86/VorbisPlugin.dll unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Windows/x86/VorbisPlugin.dll
-          cp -f out/Plugins/Windows/x86_64/VorbisPlugin.dll unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Windows/x86_64/VorbisPlugin.dll
-          cp -f out/Plugins/Android/arm64-v8a/libVorbisPlugin.so unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Android/arm64-v8a/libVorbisPlugin.so
-          cp -f out/Plugins/Android/armeabi-v7a/libVorbisPlugin.so unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Android/armeabi-v7a/libVorbisPlugin.so
-          cp -f out/Plugins/Android/x86/libVorbisPlugin.so unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Android/x86/libVorbisPlugin.so
-          cp -f out/Plugins/Android/x86_64/libVorbisPlugin.so unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Android/x86_64/libVorbisPlugin.so
-          cp -f out/Plugins/Darwin/libVorbisPlugin.dylib unity/VorbisUnity/Assets/VorbisPlugin/Plugins/OSX/libVorbisPlugin.dylib
-          cp -f out/Plugins/iOS/aarch64/libVorbisPlugin.a unity/VorbisUnity/Assets/VorbisPlugin/Plugins/iOS/libVorbisPlugin.a
-          cp -f out/Plugins/iOS/aarch64/libvorbis.a unity/VorbisUnity/Assets/VorbisPlugin/Plugins/iOS/libvorbis.a
-          cp -f out/Plugins/iOS/aarch64/libvorbisfile.a unity/VorbisUnity/Assets/VorbisPlugin/Plugins/iOS/libvorbisfile.a
-          cp -f out/Plugins/iOS/aarch64/libogg.a unity/VorbisUnity/Assets/VorbisPlugin/Plugins/iOS/libogg.a
-          cp -f out/Plugins/Linux/libVorbisPlugin.so unity/VorbisUnity/Assets/VorbisPlugin/Plugins/Linux/x86_64/libVorbisPlugin.so
+          set -euxo pipefail
+          shopt -s globstar nullglob
+
+          PROJECT_PLUGINS_DIR="unity/unity-project-vorbis/UnityClient/Assets/VorbisPlugin/Plugins"
+          mkdir -p \
+            "$PROJECT_PLUGINS_DIR/Windows/x86" \
+            "$PROJECT_PLUGINS_DIR/Windows/x86_64" \
+            "$PROJECT_PLUGINS_DIR/Android/libs/arm64-v8a" \
+            "$PROJECT_PLUGINS_DIR/Android/libs/armeabi-v7a" \
+            "$PROJECT_PLUGINS_DIR/Android/libs/x86" \
+            "$PROJECT_PLUGINS_DIR/Android/libs/x86_64" \
+            "$PROJECT_PLUGINS_DIR/OSX" \
+            "$PROJECT_PLUGINS_DIR/iOS" \
+            "$PROJECT_PLUGINS_DIR/Linux/x86_64" \
+            "$PROJECT_PLUGINS_DIR/WebGL"
+
+          WINDOWS_X86=$(find out/Plugins/Windows -type f -name VorbisPlugin.dll -path "*x86/VorbisPlugin.dll" | head -n1)
+          WINDOWS_X64=$(find out/Plugins/Windows -type f -name VorbisPlugin.dll -path "*x86_64/VorbisPlugin.dll" | head -n1)
+          cp -f "$WINDOWS_X86" "$PROJECT_PLUGINS_DIR/Windows/x86/VorbisPlugin.dll"
+          cp -f "$WINDOWS_X64" "$PROJECT_PLUGINS_DIR/Windows/x86_64/VorbisPlugin.dll"
+
+          for arch in arm64-v8a armeabi-v7a x86 x86_64; do
+            SRC=$(find out/Plugins/Android -type f -name libVorbisPlugin.so -path "*${arch}/libVorbisPlugin.so" | head -n1)
+            cp -f "$SRC" "$PROJECT_PLUGINS_DIR/Android/libs/${arch}/libVorbisPlugin.so"
+          done
+
+          MAC_DYLIB=$(find out/Plugins/Darwin -type f -name libVorbisPlugin.dylib -not -path "*arm64*" -not -path "*x86_64*" | head -n1)
+          if [ -z "$MAC_DYLIB" ]; then
+            MAC_DYLIB=$(find out/Plugins/Darwin -type f -name libVorbisPlugin.dylib | head -n1)
+          fi
+          cp -f "$MAC_DYLIB" "$PROJECT_PLUGINS_DIR/OSX/libVorbisPlugin.dylib"
+
+          for lib in libVorbisPlugin.a libvorbis.a libvorbisfile.a libvorbisenc.a libogg.a; do
+            SRC=$(find out/Plugins/iOS -type f -name "$lib" | head -n1)
+            cp -f "$SRC" "$PROJECT_PLUGINS_DIR/iOS/$lib"
+          done
+
+          for lib in libVorbisPlugin.a libvorbis.a libvorbisfile.a libvorbisenc.a libogg.a; do
+            SRC=$(find out/Plugins/WebGL -type f -name "$lib" | head -n1)
+            cp -f "$SRC" "$PROJECT_PLUGINS_DIR/WebGL/$lib"
+          done
+
+          LINUX_SO=$(find out/Plugins/Linux -type f -name libVorbisPlugin.so | head -n1)
+          cp -f "$LINUX_SO" "$PROJECT_PLUGINS_DIR/Linux/x86_64/libVorbisPlugin.so"
           git add .
           git status
           git config --global user.email "konstantin.gindemit@gmail.com"
           git config --global user.name "Konstantin Gindemit"
           git remote -v
-          git commit --allow-empty -m "New native libraries version: 0.3.0-dev.${{ github.run_number }}"
-          git tag -a 0.3.0-dev.${{ github.run_number }} -m "New native libraries version: 0.3.0-dev.${{ github.run_number }}"
+          git commit --allow-empty -m "New native libraries version: 0.5.0-dev.${{ github.run_number }}"
+          git tag -a 0.5.0-dev.${{ github.run_number }} -m "New native libraries version: 0.5.0-dev.${{ github.run_number }}"
           git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
           echo "Trying to push..."
           git push --set-upstream https://token:$MY_SECRET@github.com/gindemit/unity-wrapper-vorbis.git

--- a/projects/Android/app/build.gradle
+++ b/projects/Android/app/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'com.android.application'
 
+def enable16kPages = project.hasProperty('ANDROID_16K_PAGE') &&
+        project.property('ANDROID_16K_PAGE').toString().equalsIgnoreCase('ON')
+
 android {
     compileSdkVersion 28
     ndkVersion "27.2.12479018"
@@ -17,6 +20,9 @@ android {
             cmake {
                 arguments "-DOGG_INCLUDE_DIRS=../../../dependency/ogg/include"
                 arguments "-DVORBIS_INCLUDE_DIRS=../../../dependency/vorbis/include"
+                if (enable16kPages) {
+                    arguments "-DVORBIS_ANDROID_PAGE_SIZE_16K=ON"
+                }
             }
         }
     }

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -1,140 +1,149 @@
 # CMakeList.txt : CMake project for VorbisPlugin, include source and define
 # project specific logic here.
 
+cmake_minimum_required(VERSION 3.6)
 
-cmake_minimum_required (VERSION 3.6)
+project(VorbisPlugin C)
 
-project(VorbisPlugin)
+option(VORBIS_ANDROID_PAGE_SIZE_16K "Build Android libraries with 16KB page size" OFF)
+option(VORBIS_WEB_ASSEMBLY "Build WebAssembly static libraries" OFF)
 
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(BUILD_SHARED_LIBS FALSE)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
-set (OGG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/ogg)
-set (VORBIS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/vorbis)
-set (OGG_LIBRARIES ${CMAKE_CURRENT_BINARY_DIR}/ogg_build/lib)
-if (VORBIS_IOS)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/VorbisPluginBuild)
-elseif (VORBIS_OSX)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/VorbisPluginBuild)
-endif()
+set(OGG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/ogg)
+set(VORBIS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../dependency/vorbis)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/ogg_build/include)
+if (VORBIS_IOS)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/VorbisPluginBuild)
+elseif (VORBIS_OSX)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/VorbisPluginBuild)
+endif()
 
 add_subdirectory(${OGG_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/ogg_build)
 add_subdirectory(${VORBIS_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/vorbis_build)
 
-include_directories ($<BUILD_INTERFACE:${OGG_ROOT}/include>)
-include_directories ($<BUILD_INTERFACE:${VORBIS_ROOT}/include>)
-
-set (VORBIS_PLUGIN_LIBRARY_SOURCES 
+set(VORBIS_PLUGIN_LIBRARY_SOURCES
     ../../src/VorbisPluginEncoder.c
     ../../src/VorbisPluginDecoder.c)
-    
-if (VORBIS_IOS)
-  add_library (VorbisPlugin STATIC ${VORBIS_PLUGIN_LIBRARY_SOURCES})
+
+if (VORBIS_IOS OR VORBIS_WEB_ASSEMBLY)
+    add_library(VorbisPlugin STATIC ${VORBIS_PLUGIN_LIBRARY_SOURCES})
 else()
-  add_library (VorbisPlugin SHARED ${VORBIS_PLUGIN_LIBRARY_SOURCES})
+    add_library(VorbisPlugin SHARED ${VORBIS_PLUGIN_LIBRARY_SOURCES})
 endif()
 
 if (WIN32)
-  set(OGG_LIBRARY_NAME ogg.lib)
-  set(VORBIS_LIBRARY_NAME vorbis.lib)
-  set(VORBIS_FILE_LIBRARY_NAME vorbisfile.lib)
-  set(VORBIS_ENC_LIBRARY_NAME vorbisenc.lib)
-elseif(VORBIS_OSX)
-  set(OGG_LIBRARY_NAME libogg.a)
-  set(VORBIS_LIBRARY_NAME libvorbis.a)
-  set(VORBIS_FILE_LIBRARY_NAME libvorbisfile.a)
-  set(VORBIS_ENC_LIBRARY_NAME libvorbisenc.a)
-  #set_target_properties(VorbisPlugin PROPERTIES BUNDLE TRUE)
-  #set_target_properties(VorbisPlugin PROPERTIES SUFFIX ".bundle")
-else()
-  set(OGG_LIBRARY_NAME libogg.a)
-  set(VORBIS_LIBRARY_NAME libvorbis.a)
-  set(VORBIS_FILE_LIBRARY_NAME libvorbisfile.a)
-  set(VORBIS_ENC_LIBRARY_NAME libvorbisenc.a)
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
 endif()
 
-add_dependencies(vorbisfile vorbis ogg)
-add_dependencies(vorbis ogg)
-add_dependencies(VorbisPlugin vorbisfile vorbis ogg vorbisenc)
+# Include directories for the plugin sources
+include_directories($<BUILD_INTERFACE:${OGG_ROOT}/include>)
+include_directories($<BUILD_INTERFACE:${VORBIS_ROOT}/include>)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/ogg_build/include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/vorbis_build/include)
+
+set(VORBIS_PLUGIN_DEPENDENCIES vorbisfile vorbis vorbisenc ogg)
+
+if (MSVC)
+    target_compile_options(VorbisPlugin
+        PRIVATE
+            /std:c11
+            /W3
+            /Zc:wchar_t
+            /Zc:inline)
+else()
+    target_compile_options(VorbisPlugin
+        PRIVATE
+            -std=c11
+            -Wall
+            -Wextra
+            -Wno-unused-parameter
+            -fvisibility=hidden)
+endif()
 
 if (VORBIS_LINUX)
-  # Add 'm' to link the math library
-  target_link_libraries(VorbisPlugin m)
+    target_link_libraries(VorbisPlugin PRIVATE m)
 endif()
 
-target_link_libraries(VorbisPlugin ${CMAKE_CURRENT_BINARY_DIR}/vorbis_build/lib/$<CONFIG>/${VORBIS_FILE_LIBRARY_NAME})
-target_link_libraries(VorbisPlugin ${CMAKE_CURRENT_BINARY_DIR}/vorbis_build/lib/$<CONFIG>/${VORBIS_LIBRARY_NAME})
-target_link_libraries(VorbisPlugin ${CMAKE_CURRENT_BINARY_DIR}/ogg_build/$<CONFIG>/${OGG_LIBRARY_NAME})
-target_link_libraries(VorbisPlugin ${CMAKE_CURRENT_BINARY_DIR}/vorbis_build/lib/$<CONFIG>/${VORBIS_ENC_LIBRARY_NAME})
+target_link_libraries(VorbisPlugin PRIVATE ${VORBIS_PLUGIN_DEPENDENCIES})
 
-
-#Adding simple test program:
-add_executable(VorbisPluginTest ../../src/PluginTest.c)
-target_link_libraries(VorbisPluginTest VorbisPlugin)
-if (VORBIS_IOS)
-  set_xcode_property(VorbisPluginTest PRODUCT_BUNDLE_IDENTIFIER "com.soulside.app" All)
+if (ANDROID AND VORBIS_ANDROID_PAGE_SIZE_16K)
+    foreach(lib_target IN ITEMS VorbisPlugin ${VORBIS_PLUGIN_DEPENDENCIES})
+        if (TARGET ${lib_target})
+            target_link_options(${lib_target} PRIVATE "-Wl,-z,max-page-size=16384" "-Wl,-z,common-page-size=16384")
+        endif()
+    endforeach()
 endif()
 
 if (WIN32)
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set (VORBIS_PLUGIN_TARGET_ARCHITECTURE x86_64)
-elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-    set (VORBIS_PLUGIN_TARGET_ARCHITECTURE x86)
-endif()
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(VORBIS_PLUGIN_TARGET_ARCHITECTURE x86_64)
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(VORBIS_PLUGIN_TARGET_ARCHITECTURE x86)
+    endif()
 elseif(ANDROID)
-    set (VORBIS_PLUGIN_TARGET_ARCHITECTURE ${CMAKE_ANDROID_ARCH_ABI})
-elseif(VORBIS_IOS)
-    set (VORBIS_PLUGIN_TARGET_ARCHITECTURE ${CMAKE_OSX_ARCHITECTURES})
+    set(VORBIS_PLUGIN_TARGET_ARCHITECTURE ${CMAKE_ANDROID_ARCH_ABI})
 else()
-    set (VORBIS_PLUGIN_TARGET_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
+    set(VORBIS_PLUGIN_TARGET_ARCHITECTURE ${CMAKE_SYSTEM_PROCESSOR})
 endif()
+
+set(VORBIS_PLUGIN_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}")
+
 add_custom_command(
     TARGET VorbisPlugin POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}")
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${VORBIS_PLUGIN_OUTPUT_DIR}")
 
 add_custom_command(
     TARGET VorbisPlugin POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "$<TARGET_FILE:VorbisPlugin>"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}/$<TARGET_FILE_NAME:VorbisPlugin>"
-    COMMENT "Copied final library to out directory")
+        "${VORBIS_PLUGIN_OUTPUT_DIR}/$<TARGET_FILE_NAME:VorbisPlugin>"
+    COMMENT "Copied VorbisPlugin to out directory")
 
-# Uncomment following lines if you want to copy the pdb files for Debug builds:
-# if (WIN32)
-# add_custom_command(
-#     TARGET VorbisPlugin POST_BUILD
-#     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#         "$<TARGET_PDB_FILE:VorbisPlugin>"
-#         "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}/$<TARGET_PDB_FILE_NAME:VorbisPlugin>")
-# endif()
-# uncomment end
-if (ANDROID)
-add_custom_command(
-    TARGET VorbisPlugin POST_BUILD
-    COMMAND "${ANDROID_TOOLCHAIN_PREFIX}strip" -g -S -d --strip-debug --verbose
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}/$<TARGET_FILE_NAME:VorbisPlugin>"
-    COMMENT "Strip debug symbols done on final binary.")
+foreach(dep IN LISTS VORBIS_PLUGIN_DEPENDENCIES)
+    if (TARGET ${dep})
+        add_custom_command(
+            TARGET VorbisPlugin POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:${dep}>"
+                "${VORBIS_PLUGIN_OUTPUT_DIR}/$<TARGET_FILE_NAME:${dep}>"
+            COMMENT "Copied $<TARGET_FILE_NAME:${dep}> to out directory")
+    endif()
+endforeach()
+
+if (VORBIS_WEB_ASSEMBLY)
+    add_custom_command(
+        TARGET VorbisPlugin POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../out/Plugins/WebGL")
+    foreach(dep IN ITEMS VorbisPlugin ${VORBIS_PLUGIN_DEPENDENCIES})
+        if (TARGET ${dep})
+            add_custom_command(
+                TARGET VorbisPlugin POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    "$<TARGET_FILE:${dep}>"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/../../out/Plugins/WebGL/$<TARGET_FILE_NAME:${dep}>"
+                COMMENT "Copied $<TARGET_FILE_NAME:${dep}> to out/Plugins/WebGL")
+        endif()
+    endforeach()
 endif()
 
-if (VORBIS_IOS)
+if (ANDROID)
     add_custom_command(
         TARGET VorbisPlugin POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${CMAKE_CURRENT_BINARY_DIR}/VorbisPluginBuild/$<CONFIG>/libvorbis.a"
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}/libvorbis.a"
-        COMMENT "Copied libvorbis.a to out directory")
-    add_custom_command(
-        TARGET VorbisPlugin POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${CMAKE_CURRENT_BINARY_DIR}/VorbisPluginBuild/$<CONFIG>/libvorbisfile.a"
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}/libvorbisfile.a"
-        COMMENT "Copied libvorbisfile.a to out directory")
-    add_custom_command(
-        TARGET VorbisPlugin POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${CMAKE_CURRENT_BINARY_DIR}/VorbisPluginBuild/$<CONFIG>/libogg.a"
-            "${CMAKE_CURRENT_SOURCE_DIR}/../../out/$<CONFIG>/Plugins/$<PLATFORM_ID>/${VORBIS_PLUGIN_TARGET_ARCHITECTURE}/libogg.a"
-        COMMENT "Copied libogg.a to out directory")
+        COMMAND "${ANDROID_TOOLCHAIN_PREFIX}strip" -g -S -d --strip-debug --verbose
+                "${VORBIS_PLUGIN_OUTPUT_DIR}/$<TARGET_FILE_NAME:VorbisPlugin>"
+        COMMENT "Strip debug symbols done on final binary.")
+endif()
+
+if (NOT VORBIS_WEB_ASSEMBLY)
+    add_executable(VorbisPluginTest ../../src/PluginTest.c)
+    target_link_libraries(VorbisPluginTest VorbisPlugin)
+    if (VORBIS_IOS)
+        set_xcode_property(VorbisPluginTest PRODUCT_BUNDLE_IDENTIFIER "com.soulside.app" All)
+    endif()
 endif()

--- a/src/ExportApi.h
+++ b/src/ExportApi.h
@@ -1,10 +1,13 @@
 #ifndef _EXPORT_API_H_
 #define _EXPORT_API_H_
 
-#if _MSC_VER // this is defined when compiling with Visual Studio
-#define EXPORT_API __declspec(dllexport) // Visual Studio needs annotating exported functions with this
+#if defined(__EMSCRIPTEN__)
+#  include <emscripten/emscripten.h>
+#  define EXPORT_API EMSCRIPTEN_KEEPALIVE
+#elif defined(_MSC_VER)
+#  define EXPORT_API __declspec(dllexport)
 #else
-#define EXPORT_API // XCode or Android Studio does not need annotating exported functions, so define is empty
+#  define EXPORT_API __attribute__((visibility("default")))
 #endif
 
 #endif // !_EXPORT_API_H_

--- a/src/VorbisPlugin.h
+++ b/src/VorbisPlugin.h
@@ -2,9 +2,14 @@
 #define _VORBIS_PLUGIN_H_
 
 #include "ExportApi.h"
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <vorbis/vorbisfile.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct vorbis_file_read_stream_state {
     FILE* file_stream;
@@ -14,47 +19,55 @@ typedef struct vorbis_file_read_stream_state {
     vorbis_info* vi;
 } vorbis_file_read_stream_state;
 
-
 EXPORT_API int32_t write_all_pcm_data_to_file(
-    const char *file_path,
-    const float *samples,
-    const int32_t samples_length,
-    const int16_t channels,
-    const int32_t frequency,
-    const float base_quality,
-    const int32_t samples_to_read);
-EXPORT_API int32_t write_all_pcm_data_to_memory(
-    char **memory_array,
-    int32_t *memory_array_length,
+    const char* file_path,
     const float* samples,
-    const int32_t samples_length,
-    const int16_t channels,
-    const int32_t frequency,
-    const float base_quality,
-    const int32_t samples_to_read);
-EXPORT_API int32_t free_memory_array_for_write_all_pcm_data(char *memory_array);
-
+    int32_t samples_length,
+    int16_t channels,
+    int32_t frequency,
+    float base_quality,
+    int32_t samples_to_read);
+EXPORT_API int32_t write_all_pcm_data_to_memory(
+    char** memory_array,
+    int32_t* memory_array_length,
+    const float* samples,
+    int32_t samples_length,
+    int16_t channels,
+    int32_t frequency,
+    float base_quality,
+    int32_t samples_to_read);
+EXPORT_API int32_t free_memory_array_for_write_all_pcm_data(char* memory_array);
 
 EXPORT_API int32_t read_all_pcm_data_from_file(
-    const char *file_path,
-    float **samples,
-    int32_t *samples_length,
-    int16_t *channels,
-    int32_t *frequency,
-    const int32_t max_samples_to_read);
-EXPORT_API int32_t read_all_pcm_data_from_memory(
-    const char* memory_array,
-    const int32_t memory_array_length,
+    const char* file_path,
     float** samples,
     int32_t* samples_length,
     int16_t* channels,
     int32_t* frequency,
-    const int32_t max_samples_to_read);
-EXPORT_API int32_t free_samples_array_native_memory(float **samples);
+    int32_t max_samples_to_read);
+EXPORT_API int32_t read_all_pcm_data_from_memory(
+    const char* memory_array,
+    int32_t memory_array_length,
+    float** samples,
+    int32_t* samples_length,
+    int16_t* channels,
+    int32_t* frequency,
+    int32_t max_samples_to_read);
+EXPORT_API int32_t free_samples_array_native_memory(float** samples);
 
-EXPORT_API int32_t open_read_file_stream(vorbis_file_read_stream_state **state, const char *file_path, int16_t *channels, int32_t *frequency);
-EXPORT_API int32_t read_from_file_stream(vorbis_file_read_stream_state *state, float *samples_to_fill, const int32_t max_samples_to_read);
-EXPORT_API int32_t close_file_stream(vorbis_file_read_stream_state *state);
+EXPORT_API int32_t open_read_file_stream(
+    vorbis_file_read_stream_state** state,
+    const char* file_path,
+    int16_t* channels,
+    int32_t* frequency);
+EXPORT_API int32_t read_from_file_stream(
+    vorbis_file_read_stream_state* state,
+    float* samples_to_fill,
+    int32_t max_samples_to_read);
+EXPORT_API int32_t close_file_stream(vorbis_file_read_stream_state* state);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif // !_VORBIS_PLUGIN_H_


### PR DESCRIPTION
## Summary
- update the build workflow to run on the dev branch, cover all desktop, mobile, and WebGL targets, and automate refreshing the Unity project assets
- add Android 16KB page size support, WebGL outputs, and architecture-aware copy steps to the native CMake build
- modernize shared headers and Gradle configuration for consistent exports across toolchains

## Testing
- not run (changes affect CI workflows and build configuration)

------
https://chatgpt.com/codex/tasks/task_e_68c86196fb44832f85f33c25de93a260