### PR TITLE
Fix CI builds for Android, WebGL, and Vorbis

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -45,30 +45,33 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Install Android SDK Command-line Tools
         run: |
           mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
-          curl -fo sdk-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-8512546_latest.zip
-          unzip sdk-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
+          curl -fo sdk-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
+          unzip -q sdk-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
           mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
 
       - name: Accept Licenses
-        run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
+        run: yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses
 
       - name: Install CMake and NDK
         run: |
-          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1" "ndk;27.2.12479018"
+          "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "cmake;3.22.1" "ndk;27.2.12479018"
 
       - name: Set execution permissions for gradlew
         run: chmod +x projects/Android/gradlew
 
       - name: Build Gradle project
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_SDK_ROOT }}/ndk/27.2.12479018
+          ANDROID_NDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}/ndk/27.2.12479018
         run: |
           sudo apt-get update
           sudo apt-get install -y tree
@@ -206,7 +209,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Emscripten 3.1.39
-        uses: emscripten-core/setup-emscripten@v3
+        uses: mymindstorm/setup-emsdk@v14
         with:
           version: 3.1.39
 

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -23,6 +23,13 @@ elseif (VORBIS_OSX)
 endif()
 
 add_subdirectory(${OGG_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/ogg_build)
+
+# Allow the in-tree Vorbis build to reuse the ogg target we just added instead of
+# searching the host system for an installed libogg.
+set(OGG_INCLUDE_DIR  ${OGG_ROOT}/include CACHE PATH "" FORCE)
+set(OGG_INCLUDE_DIRS ${OGG_ROOT}/include CACHE PATH "" FORCE)
+set(OGG_LIBRARIES ogg CACHE STRING "" FORCE)
+
 add_subdirectory(${VORBIS_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/vorbis_build)
 
 set(VORBIS_PLUGIN_LIBRARY_SOURCES


### PR DESCRIPTION
## Summary
- switch the Android workflow to JDK 17, the latest command line tools, and export the selected NDK to Gradle
- replace the deprecated WebGL setup action with mymindstorm/setup-emsdk@v14
- point the Vorbis CMake build at the in-tree ogg target so macOS/iOS builds no longer search the host system

## Testing
- not run (CI workflow updates)


------
https://chatgpt.com/codex/tasks/task_e_68c87983cf10832f8f7f3b85e26900da