### PR TITLE
Fix multi-platform build integration issues

### DIFF
--- a/.github/workflows/build_native_libraries.yaml
+++ b/.github/workflows/build_native_libraries.yaml
@@ -40,10 +40,16 @@ jobs:
   build_android:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout code (with LFS)
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
+
+      - name: Git LFS pull
+        run: |
+          git lfs install
+          git lfs pull
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -59,25 +65,22 @@ jobs:
           mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
 
       - name: Accept Licenses
-        run: yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses
+        run: yes | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --licenses
 
       - name: Install CMake and NDK
         run: |
-          "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "cmake;3.22.1" "ndk;27.2.12479018"
+          $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1" "ndk;27.2.12479018"
 
-      - name: Set execution permissions for gradlew
+      - name: Ensure gradlew is executable
         run: chmod +x projects/Android/gradlew
 
       - name: Build Gradle project
-        env:
-          ANDROID_NDK_HOME: ${{ env.ANDROID_SDK_ROOT }}/ndk/27.2.12479018
-          ANDROID_NDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}/ndk/27.2.12479018
         run: |
-          sudo apt-get update
-          sudo apt-get install -y tree
+          set -euxo pipefail
           cd projects/Android
-          ./gradlew -PANDROID_16K_PAGE=ON assembleRelease
-          tree ../../out
+          ./gradlew assembleRelease -PVORBIS_ANDROID_PAGE_SIZE_16K=ON
+          cd ../..
+          tree -a out || true
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/projects/Android/app/build.gradle
+++ b/projects/Android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
-def enable16kPages = project.hasProperty('ANDROID_16K_PAGE') &&
-        project.property('ANDROID_16K_PAGE').toString().equalsIgnoreCase('ON')
+def enable16kPages = project.hasProperty('VORBIS_ANDROID_PAGE_SIZE_16K') &&
+        project.property('VORBIS_ANDROID_PAGE_SIZE_16K').toString().equalsIgnoreCase('ON')
 
 android {
     compileSdkVersion 28
@@ -18,6 +18,7 @@ android {
         }
         externalNativeBuild {
             cmake {
+                cppFlags '-std=c11'
                 arguments "-DOGG_INCLUDE_DIRS=../../../dependency/ogg/include"
                 arguments "-DVORBIS_INCLUDE_DIRS=../../../dependency/vorbis/include"
                 if (enable16kPages) {

--- a/projects/CMake/CMakeLists.txt
+++ b/projects/CMake/CMakeLists.txt
@@ -5,6 +5,10 @@ cmake_minimum_required(VERSION 3.6)
 
 project(VorbisPlugin C)
 
+if (MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
+
 option(VORBIS_ANDROID_PAGE_SIZE_16K "Build Android libraries with 16KB page size" OFF)
 option(VORBIS_WEB_ASSEMBLY "Build WebAssembly static libraries" OFF)
 
@@ -42,11 +46,6 @@ else()
     add_library(VorbisPlugin SHARED ${VORBIS_PLUGIN_LIBRARY_SOURCES})
 endif()
 
-if (WIN32)
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
-    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
-endif()
-
 # Include directories for the plugin sources
 include_directories($<BUILD_INTERFACE:${OGG_ROOT}/include>)
 include_directories($<BUILD_INTERFACE:${VORBIS_ROOT}/include>)
@@ -73,7 +72,7 @@ else()
 endif()
 
 if (VORBIS_LINUX)
-    target_link_libraries(VorbisPlugin PRIVATE m)
+    target_link_libraries(VorbisPlugin PUBLIC m)
 endif()
 
 target_link_libraries(VorbisPlugin PRIVATE ${VORBIS_PLUGIN_DEPENDENCIES})
@@ -150,6 +149,9 @@ endif()
 if (NOT VORBIS_WEB_ASSEMBLY)
     add_executable(VorbisPluginTest ../../src/PluginTest.c)
     target_link_libraries(VorbisPluginTest VorbisPlugin)
+    if (UNIX AND NOT APPLE)
+        target_link_libraries(VorbisPluginTest m)
+    endif()
     if (VORBIS_IOS)
         set_xcode_property(VorbisPluginTest PRODUCT_BUNDLE_IDENTIFIER "com.soulside.app" All)
     endif()

--- a/src/PluginTest.c
+++ b/src/PluginTest.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <math.h>
+#include <stdint.h>
 
 const char* OGG_TEST_FILE_NAME = "1_ogg_plugin_test.ogg";
 
@@ -107,9 +108,9 @@ static void test_decode_from_memory() {
     assert(memory_buffer_length > 0);
 
     float *samples;
-    long samples_filled_length;
+    int32_t samples_filled_length;
     short channels;
-    long frequency;
+    int32_t frequency;
     read_all_pcm_data_from_memory(
         memory_buffer,
         memory_buffer_length,


### PR DESCRIPTION
## Summary
- align the MSVC runtime and share libm linkage from the Vorbis plugin target
- use the correct 32-bit integer types in the PluginTest helper when calling the API
- update the Android Gradle property handling and CI to pull LFS assets and pass the matching flag

## Testing
- cmake -S projects/CMake -B buildLinux -G "Unix Makefiles" -DVORBIS_LINUX=1
- cmake --build buildLinux --config Release

------
https://chatgpt.com/codex/tasks/task_e_68c87fbf5d04832f895549dfaf549b35